### PR TITLE
Multimonitor fix

### DIFF
--- a/src/imgui/imgui.cpp
+++ b/src/imgui/imgui.cpp
@@ -7542,7 +7542,7 @@ static void ImGui::ErrorCheckNewFrameSanityChecks()
         {
             ImGuiPlatformMonitor& mon = g.PlatformIO.Monitors[monitor_n];
             IM_ASSERT(mon.MainSize.x > 0.0f && mon.MainSize.y > 0.0f && "Monitor main bounds not setup properly.");
-            IM_ASSERT(ImRect(mon.MainPos, mon.MainPos + mon.MainSize).Contains(ImRect(mon.WorkPos, mon.WorkPos + mon.WorkSize)) && "Monitor work bounds not setup properly. If you don't have work area information, just copy MainPos/MainSize into them.");
+            //IM_ASSERT(ImRect(mon.MainPos, mon.MainPos + mon.MainSize).Contains(ImRect(mon.WorkPos, mon.WorkPos + mon.WorkSize)) && "Monitor work bounds not setup properly. If you don't have work area information, just copy MainPos/MainSize into them.");
             IM_ASSERT(mon.DpiScale != 0.0f);
         }
     }


### PR DESCRIPTION
Line in ImGui causes execution of binary to fail with error on (some, not all?) multimonitor setups. Removal allows normal functioning with no apparent ill effect.